### PR TITLE
Update lfw_fuel to use latest Keras and Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to indicate whether the pairs are same or different. In addition
 to the original lfw dataset, conversion is supported for both
 the funneled and deepfunneled versions of the images.
 
-This project uses [kerosene](https://github.com/dribnet/kerosene) to produce a [fuel](https://github.com/mila-udem/fuel) comptable
+This project uses [kerosene](https://github.com/dribnet/kerosene) to produce a [fuel](https://github.com/mila-udem/fuel)-compatible
 hdf5 file that is usable by [blocks](https://github.com/mila-udem/blocks) or [keras](https://github.com/fchollet/keras).
 
 ## Show me
@@ -38,8 +38,8 @@ to the network as shown in the example.
 
 ## What's this dataset all about again?
 
-The primary task of Labeled Faces in the Wild is to learn wheather the face
-in two pictures are the same person, or two different people. There are
+The primary task of Labeled Faces in the Wild is to learn whether the faces
+in two pictures are of the same person, or two different people. There are
 2200 training pairs and 1000 test pairs in the predefined split.
 
 Here are three matching training pairs:

--- a/example/run-lfw.py
+++ b/example/run-lfw.py
@@ -50,24 +50,24 @@ Y_test = np_utils.to_categorical(y_test, nb_classes)
 
 model = Sequential()
 
-model.add(Convolution2D(32, 6, 3, 3, border_mode='full'))
+model.add(Conv2D(32, (3,3), input_shape=(6,32,32), padding='valid'))
 model.add(Activation('relu'))
-model.add(Convolution2D(32, 32, 3, 3))
+model.add(Conv2D(32, (3,3), input_shape=(6,32,32), padding='valid'))
 model.add(Activation('relu'))
 model.add(MaxPooling2D(poolsize=(2, 2)))
 model.add(Dropout(0.25))
 
 model.add(Flatten())
-model.add(Dense(feature_width*feature_height*8, 128))
+model.add(Dense(128))
 model.add(Activation('relu'))
 model.add(Dropout(0.5))
 
-model.add(Dense(128, nb_classes))
+model.add(Dense(nb_classes))
 model.add(Activation('softmax'))
 
-model.compile(loss='categorical_crossentropy', optimizer='adadelta')
+model.compile(loss='categorical_crossentropy', metrics=['binary_accuracy'], optimizer='adadelta')
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Y_test))
-score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
+model.fit(X_train, Y_train, batch_size=batch_size, epochs=nb_epoch, verbose=1, validation_data=(X_test, Y_test))
+score = model.evaluate(X_test, Y_test, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/example/run-lfw.py
+++ b/example/run-lfw.py
@@ -37,8 +37,8 @@ def cropImage(im):
 # the data, shuffled and split between train and test sets
 (X_train, y_train), (X_test, y_test) = lfw.load_data("deepfunneled")
 # crop features
-X_train = np.asarray(map(cropImage, X_train))
-X_test = np.asarray(map(cropImage, X_test))
+X_train = np.asarray(list(map(cropImage, X_train)))
+X_test = np.asarray(list(map(cropImage, X_test)))
 
 # print shape of data while model is building
 print("{1} train samples, {2} channel{0}, {3}x{4}".format("" if X_train.shape[1] == 1 else "s", *X_train.shape))

--- a/example/run-lfw.py
+++ b/example/run-lfw.py
@@ -21,53 +21,64 @@ from lfw_fuel import lfw
 '''
 
 batch_size = 128
-nb_classes = 2
 nb_epoch = 12
 feature_width = 32
 feature_height = 32
+downsample_size = 32
 
-def cropImage(im):
-    im2 = np.dstack(im).astype(np.uint8)
-    # return centered 128x128 from original 250x250 (40% of area)
-    newim = im2[61:189, 61:189]
-    sized1 = imresize(newim[:,:,0:3], (feature_width, feature_height), interp="bicubic", mode="RGB")
-    sized2 = imresize(newim[:,:,3:6], (feature_width, feature_height), interp="bicubic", mode="RGB")
-    return np.asarray([sized1[:,:,0], sized1[:,:,1], sized1[:,:,2], sized2[:,:,0], sized2[:,:,1], sized2[:,:,2]])
+def crop_and_downsample(originalX):
+    """
+    Starts with a 250 x 250 image.
+    Crops to 128 x 128 around the center.
+    Downsamples the image to (downsample_size) x (downsample_size).
+    Returns an image with dimensions (channel, width, height).
+    """
+    current_dim = 250
+    target_dim = 128
+    margin = int((current_dim - target_dim)/2)
+    left_margin = margin
+    right_margin = current_dim - margin
+
+    # newim is shape (6, 128, 128)
+    newim = originalX[:, left_margin:right_margin, left_margin:right_margin]
+
+    # resized are shape (feature_width, feature_height, 3)
+    feature_width = feature_height = downsample_size
+    resized1 = imresize(newim[0:3,:,:], (feature_width, feature_height), interp="bicubic", mode="RGB")
+    resized2 = imresize(newim[3:6,:,:], (feature_width, feature_height), interp="bicubic", mode="RGB")
+
+    # re-packge into a new X entry
+    newX = np.concatenate([resized1,resized2], axis=2)
+
+    # the next line is important.
+    # if you don't normalize your data, all predictions will be 0 forever.
+    newX = newX/255.0
+
+    return newX
+
+(X_train, y_train), (X_test, y_test) = lfw.load_data("deepfunneled")
 
 # the data, shuffled and split between train and test sets
-(X_train, y_train), (X_test, y_test) = lfw.load_data("deepfunneled")
-# crop features
-X_train = np.asarray(list(map(cropImage, X_train)))
-X_test = np.asarray(list(map(cropImage, X_test)))
+X_train = np.asarray([crop_and_downsample(x) for x in X_train])
+X_test  = np.asarray([crop_and_downsample(x) for x in X_test])
 
 # print shape of data while model is building
 print("{1} train samples, {2} channel{0}, {3}x{4}".format("" if X_train.shape[1] == 1 else "s", *X_train.shape))
 print("{1}  test samples, {2} channel{0}, {3}x{4}".format("" if X_test.shape[1] == 1 else "s", *X_test.shape))
 
-# convert class vectors to binary class matrices
-Y_train = np_utils.to_categorical(y_train, nb_classes)
-Y_test = np_utils.to_categorical(y_test, nb_classes)
-
 model = Sequential()
 
-model.add(Conv2D(32, (3,3), input_shape=(6,32,32), padding='valid'))
-model.add(Activation('relu'))
-model.add(Conv2D(32, (3,3), input_shape=(6,32,32), padding='valid'))
-model.add(Activation('relu'))
-model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Conv2D(32, (5,5), input_shape=(downsample_size,downsample_size,6), padding='same', data_format='channels_last', activation='relu'))
+model.add(Conv2D(32, (5,5), padding='same', data_format='channels_last', activation='relu'))
+model.add(MaxPooling2D(pool_size=(2,2), data_format='channels_last'))
 model.add(Dropout(0.25))
-
 model.add(Flatten())
-model.add(Dense(128))
-model.add(Activation('relu'))
+model.add(Dense(128, activation='relu'))
 model.add(Dropout(0.5))
+model.add(Dense(1, activation='sigmoid'))
 
-model.add(Dense(nb_classes))
-model.add(Activation('softmax'))
-
-model.compile(loss='categorical_crossentropy', metrics=['binary_accuracy'], optimizer='adadelta')
-
-model.fit(X_train, Y_train, batch_size=batch_size, epochs=nb_epoch, verbose=1, validation_data=(X_test, Y_test))
-score = model.evaluate(X_test, Y_test, verbose=0)
+model.compile(loss='binary_crossentropy', metrics=['binary_accuracy'], optimizer='adadelta')
+model.fit(X_train, y_train, batch_size=batch_size, epochs=nb_epoch, verbose=1, validation_data=(X_test, y_test))
+score = model.evaluate(X_test, y_test, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/example/run-lfw.py
+++ b/example/run-lfw.py
@@ -5,7 +5,7 @@ np.random.seed(1337)  # for reproducibility
 
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation, Flatten
-from keras.layers.convolutional import Convolution2D, MaxPooling2D
+from keras.layers.convolutional import Conv2D, MaxPooling2D
 from keras.utils import np_utils
 from scipy.misc import imresize 
 
@@ -54,7 +54,7 @@ model.add(Conv2D(32, (3,3), input_shape=(6,32,32), padding='valid'))
 model.add(Activation('relu'))
 model.add(Conv2D(32, (3,3), input_shape=(6,32,32), padding='valid'))
 model.add(Activation('relu'))
-model.add(MaxPooling2D(poolsize=(2, 2)))
+model.add(MaxPooling2D(pool_size=(2, 2)))
 model.add(Dropout(0.25))
 
 model.add(Flatten())

--- a/lfw_fuel/lfw.py
+++ b/lfw_fuel/lfw.py
@@ -51,7 +51,7 @@ def resolve_filename(format):
 def downloader_wrapper(format, directory, **kwargs):
     # add the right format file to the download list
     files.insert(0, "{}.tgz".format(resolve_filename(format)))
-    urls = map(lambda s: 'http://vis-www.cs.umass.edu/lfw/' + s, files)
+    urls = list(map(lambda s: 'http://vis-www.cs.umass.edu/lfw/' + s, files))
     default_downloader(directory, urls=urls, filenames=files, **kwargs)
 
 # this subparser hook is used for briq-download
@@ -67,7 +67,7 @@ def download_subparser(subparser):
     subparser.add_argument(
         "--format", help="alternate format", type=str, default=None)
 
-    urls = map(lambda s: 'http://vis-www.cs.umass.edu/lfw/' + s, files)
+    urls = list(map(lambda s: 'http://vis-www.cs.umass.edu/lfw/' + s, files))
 
     return downloader_wrapper
 
@@ -131,8 +131,8 @@ def convert_lfw(directory, basename, output_directory):
     train_images = load_images("train", tar, tar_subdir, trainrows)
     test_images  = load_images("test",  tar, tar_subdir, testrows)
 
-    train_labels = np.array(map(lambda r:loadLabelsFromRow(r), trainrows))
-    test_labels = np.array(map(lambda r:loadLabelsFromRow(r), testrows))
+    train_labels = np.array(list(map(lambda r:loadLabelsFromRow(r), trainrows)))
+    test_labels = np.array(list(map(lambda r:loadLabelsFromRow(r), testrows)))
 
     train_features = np.array([[f[0,:,:,0], f[0,:,:,1], f[0,:,:,2], f[1,:,:,0], f[1,:,:,1], f[1,:,:,2]] for f in train_images])
     test_features  = np.array([[f[0,:,:,0], f[0,:,:,1], f[0,:,:,2], f[1,:,:,0], f[1,:,:,1], f[1,:,:,2]] for f in test_images])

--- a/lfw_fuel/lfw.py
+++ b/lfw_fuel/lfw.py
@@ -121,9 +121,9 @@ def convert_lfw(directory, basename, output_directory):
 
     print("--> Building test/train lists")
     # build lists, throwing away heading
-    with open('pairsDevTrain.txt', 'rb') as csvfile:
+    with open('pairsDevTrain.txt', 'r') as csvfile:
         trainrows = list(csv.reader(csvfile, delimiter='\t'))[1:]
-    with open('pairsDevTest.txt', 'rb') as csvfile:
+    with open('pairsDevTest.txt', 'r') as csvfile:
         testrows = list(csv.reader(csvfile, delimiter='\t'))[1:]
 
     print("--> Converting")


### PR DESCRIPTION
This commit mainly affects the `lfw_fuel` example CNN. It brings the neural network up to date with the latest Keras API, and updates two lines to play nice with both Python 2 and Python 3.

Note that the call to `np.asarray(list(map(cropImage, X)))` is comparable in speed to uglier multi-line alternatives (like pre-allocating an empty array and populating it one element at a time). See [this gist](https://gist.github.com/charlesreid1/436c51eae1e6a0d011d86f3796dec853) for a timing comparison. 

[This SO thread](http://stackoverflow.com/questions/367565/how-do-i-build-a-numpy-array-from-a-generator#580416) is also interesting. It mentions `np.fromiter()`, which unfortunately only works for 1D arrays.